### PR TITLE
Add Vercel internship to about section

### DIFF
--- a/utils/commandHelper.js
+++ b/utils/commandHelper.js
@@ -80,7 +80,7 @@ export const CONTENTS = {
       <div class="command">Type one of the above to view. For eg. <span style="color: var(--secondary)">about</span></div>`,
   about: () => `My name is Kavin Desi Valli. I'm a Computer Engineering student at the <a href="https://uwaterloo.ca/content/home" target="_blank">University of Waterloo</a> (CE '28) and a fullstack web developer.
     <br/><br/>
-    I ship developer tooling at <a href="https://www.helicone.ai" target="_blank">Helicone</a> (YC '23), covering LLM observability, multilingual SDKs, and production-grade Next.js features, after previously building embedded full stack systems at <a href="https://www.arcturusnetworks.com" target="_blank">Arcturus Networks</a>.
+    I'm currently interning at <a href="https://vercel.com" target="_blank">Vercel</a>. Previously, I shipped developer tooling at <a href="https://www.helicone.ai" target="_blank">Helicone</a> (YC '23), covering LLM observability, multilingual SDKs, and production-grade Next.js features, and built embedded full stack systems at <a href="https://www.arcturusnetworks.com" target="_blank">Arcturus Networks</a>.
     <br /><br />
     I used to run <a href="https://youtube.com/@livecode247" target="_blank">LiveCode247</a> (202K+ views, 8K watch hours), and served as President of <a href="https://exunclan.com" target="_blank">Exun Clan</a> ('22-23).
     <br />


### PR DESCRIPTION
Updates the `about` command in the terminal portfolio to reflect that Kavin is currently interning at Vercel, and reframes Helicone and Arcturus Networks as previous experience.

<a href="https://v0-preview.slack.com/archives/C0AGMLN99R9/p1775089379184999?thread_ts=1775089379.184999&cid=C0AGMLN99R9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0chat-git-gaspar09-slack-v0-agent-routing.vercel.sh/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0chat-git-gaspar09-slack-v0-agent-routing.vercel.sh/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0chat-git-gaspar09-slack-v0-agent-routing.vercel.sh/chat-static/slack-light.svg" width="108" height="30"></picture></a>