### PR TITLE
Update portfolio with current work experience, projects, and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-The site is published [here](https://kavin.me)
+# kavin.me
 
-v0 edited this readme
+A terminal-based portfolio website for [Kavin Desi Valli](https://kavin.me).
 
-Hello World
+Built with Next.js. Type `help` to see available commands including `about`, `work`, `skills`, `projects`, `education`, `contact`, and more.
+
+The normal (non-terminal) version lives at [n.kavin.me](https://n.kavin.me) ([kavinvalli/normal-website](https://github.com/kavinvalli/normal-website)).

--- a/app/api/contacts/route.js
+++ b/app/api/contacts/route.js
@@ -11,14 +11,14 @@ export async function GET(request) {
       link: "mailto:mail@kavin.me",
     },
     {
-      medium: "facebook",
-      username: "kavin.valli.25",
-      link: "https://www.facebook.com/kavin.valli.25/",
-    },
-    {
       medium: "linkedin",
       username: "kavinvalli",
       link: "https://www.linkedin.com/in/kavinvalli/",
+    },
+    {
+      medium: "twitter",
+      username: "kavinvalli",
+      link: "https://twitter.com/kavinvalli",
     },
   ];
 

--- a/app/api/projects/route.js
+++ b/app/api/projects/route.js
@@ -1,70 +1,77 @@
 export async function GET(request) {
   const projects = [
     {
+      name: "Helicone",
+      description:
+        "Open-source LLM observability platform (YC W23). Shipped developer tooling including multilingual SDKs, production Next.js features, and core observability functionality. 5.4K+ stars on GitHub.",
+      stack: ["TypeScript", "Next.js", "PostgreSQL", "ClickHouse"],
+      link: "https://github.com/Helicone/helicone",
+      image: "ndss.png",
+    },
+    {
+      name: "Helicone AI Gateway",
+      description:
+        "The fastest, lightest, and easiest-to-integrate open-source AI gateway. Built with Rust for high performance. Supports caching, rate-limiting, load balancing, and observability. 550+ stars.",
+      stack: ["Rust", "TypeScript"],
+      link: "https://github.com/Helicone/ai-gateway",
+      image: "ndss.png",
+    },
+    {
+      name: "Typewind",
+      description:
+        "Core maintainer of Typewind - bringing the safety of TypeScript to the magic of Tailwind CSS. 2.2K+ stars on GitHub.",
+      stack: ["TypeScript"],
+      link: "https://typewind.dev/",
+      image: "ndss.png",
+    },
+    {
       name: "Liberty: Experience the ISS like never before.",
       description:
-        "A browser based 3D visualisation of the International Space Station in Realtime which won us second place in the NASA Space Apps Regional Round among 90+ teams.",
-      stack: ["Typescript", "NextJS", "Rust", "WASM"],
+        "A browser-based 3D visualisation of the International Space Station in realtime. Won second place in the NASA Space Apps Regional Round among 90+ teams.",
+      stack: ["TypeScript", "Next.js", "Rust", "WASM"],
       link: "https://space-apps-eosin.vercel.app",
       image: "ndss.png",
       largeImage: "liberty-lg.png",
     },
     {
-      name: "New Delhi Space Society Website",
+      name: "gh-repo-fzf",
       description:
-        "I designed and developed New Delhi Space Society’s Website - A chapter of the National Space Society",
-      stack: ["Typescript", "NextJS"],
-      link: "https://new-delhi-space-society.github.io/",
+        "A GitHub CLI extension to fuzzy search your repositories and perform actions on them. 45+ stars.",
+      stack: ["Shell", "GitHub CLI"],
+      link: "https://github.com/kavinvalli/gh-repo-fzf",
       image: "ndss.png",
-      largeImage: "ndss-lg.png",
-    },
-    {
-      name: "Wunderkind - DPS Goethe Quiz",
-      description:
-        "Helped in creating a platform (website) for a quiz conducted by Goethe Institut in collaboration DPS Society. The platform was used by over 9000 students in 2 iterations of the quiz and boasted a 99% availability rating. The platform was orchestrated at minimal cost to the operators and used cutting-edge web technology.",
-      stack: ["PHP", "Laravel", "Typescript", "ReactJS"],
-      link: "https://dpsgoethequiz.com",
-      image: "cognizer.png",
-    },
-    {
-      name: "Cognizer",
-      description:
-        "A Chrome Extension that allows you to connect with people during and also soon after the conference or meet ends. Second Runner's up at Code Warriors soBig.s Hackathon 2021",
-      stack: ["Javascript", "NodeJS", "Adonis", "Chrome Extension API"],
-      link: "https://cognizer.kavin.me/",
-      image: "cognizer.png",
     },
     {
       name: "Sudocrypt v11.0",
       description:
-        "I developed the platform for Sudocrypt v11.0, a cryptic hunt organized by Exun Clan. It had over 1.5k participants and more than 50k attempts over the course of two days.",
-      stack: ["PHP", "Laravel", "Typescript", "ReactJS"],
+        "Developed the platform for Sudocrypt v11.0, a cryptic hunt organized by Exun Clan. It had over 1.5K participants and more than 50K attempts over the course of two days.",
+      stack: ["PHP", "Laravel", "TypeScript", "React"],
       link: "https://github.com/kavinvalli/sudocrypt-v11",
       image: "sudocrypt.png",
     },
     {
-      name: "CBSE Rebrand",
+      name: "RITA - React, Inertia, TypeScript, Adonis",
       description:
-        "Rebranded CBSE Platform made using AdonisJS for CORE 2021. Creative Winners",
-      stack: ["Javascript", "NodeJS", "Adonis"],
-      link: "https://github.com/kavinvalli/core-cbse-rebrand-2021",
-      image: "cbse.png",
+        "Batteries-included starter for full-stack AdonisJS apps with React, Inertia.js, and TypeScript. 38 stars.",
+      stack: ["TypeScript", "AdonisJS", "React", "Inertia.js"],
+      link: "https://github.com/kavinvalli/rita",
+      image: "ndss.png",
+    },
+    {
+      name: "Wunderkind - DPS Goethe Quiz",
+      description:
+        "Platform for a quiz conducted by Goethe Institut in collaboration with DPS Society. Used by over 9,000 students across 2 iterations with 99% availability.",
+      stack: ["PHP", "Laravel", "TypeScript", "React"],
+      link: "https://dpsgoethequiz.com",
+      image: "cognizer.png",
     },
     {
       name: "Discord Task Manager Bot",
       description:
-        "A Task Manager Bot you can add to your discord servers (created with the help of the Discord API)",
-      stack: ["Javascript", "NodeJS"],
+        "A task management bot for Discord servers. Open source with community contributions. 18 stars.",
+      stack: ["JavaScript", "Node.js", "Discord.js"],
       link: "https://task-manager-bot.github.io",
       image: "task-bot.png",
-    },
-    {
-      name: "Cricket VSCode Extension",
-      description:
-        "A VSCode Extension to show Cricket News and LiveScores from inside the editor",
-      stack: ["Javascript"],
-      link: "https://github.com/kavin25/cricket-vscode-extension",
-      image: "cricket-vscode.png",
     },
   ];
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/react": "19.2.14",
     "eslint": "8.9.0",
     "eslint-config-next": "12.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
       eslint:
         specifier: 8.9.0
         version: 8.9.0
@@ -69,24 +72,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.15':
     resolution: {integrity: sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.15':
     resolution: {integrity: sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.15':
     resolution: {integrity: sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.15':
     resolution: {integrity: sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==}
@@ -135,6 +142,9 @@ packages:
 
   '@types/node@14.18.63':
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@typescript-eslint/parser@5.62.0':
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
@@ -305,6 +315,9 @@ packages:
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -1311,6 +1324,10 @@ snapshots:
 
   '@types/node@14.18.63': {}
 
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
@@ -1520,6 +1537,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  csstype@3.2.3: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.1:
@@ -1710,8 +1729,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.9.0)(typescript@5.6.3)
       eslint: 8.9.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0)(eslint@8.9.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.9.0)
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0(eslint@8.9.0))(eslint@8.9.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.9.0))(eslint@8.9.0))(eslint@8.9.0)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.9.0)
       eslint-plugin-react: 7.37.1(eslint@8.9.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.9.0)
@@ -1730,11 +1749,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.9.0):
+  eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.9.0))(eslint@8.9.0):
     dependencies:
       debug: 4.3.7
       eslint: 8.9.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.9.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.9.0))(eslint@8.9.0))(eslint@8.9.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.8
@@ -1742,18 +1761,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.9.0))(eslint@8.9.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.9.0))(eslint@8.9.0))(eslint@8.9.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.9.0)(typescript@5.6.3)
       eslint: 8.9.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0)(eslint@8.9.0)
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.31.0(eslint@8.9.0))(eslint@8.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.9.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.9.0))(eslint@8.9.0))(eslint@8.9.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -1764,7 +1783,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.9.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0)(eslint@8.9.0))(eslint@8.9.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.9.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@8.9.0))(eslint@8.9.0))(eslint@8.9.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/utils/commandHelper.js
+++ b/utils/commandHelper.js
@@ -8,6 +8,10 @@ const COMMANDS = [
     description: "My Education",
   },
   {
+    command: "work",
+    description: "My Work Experience",
+  },
+  {
     command: "skills",
     description: "My Tech Skills",
   },
@@ -78,24 +82,39 @@ export const CONTENTS = {
     ).join("") +
     `<br />
       <div class="command">Type one of the above to view. For eg. <span style="color: var(--secondary)">about</span></div>`,
-  about: () => `My name is Kavin Desi Valli. I'm a Computer Engineering student at the <a href="https://uwaterloo.ca/content/home" target="_blank">University of Waterloo</a> (CE '28) and a fullstack web developer.
+  about: () => `My name is Kavin Desi Valli. I'm a Computer Engineering student at the <a href="https://uwaterloo.ca/content/home" target="_blank">University of Waterloo</a> (CE '28) and a fullstack developer.
     <br/><br/>
-    I ship developer tooling at <a href="https://www.helicone.ai" target="_blank">Helicone</a> (YC '23), covering LLM observability, multilingual SDKs, and production-grade Next.js features, after previously building embedded full stack systems at <a href="https://www.arcturusnetworks.com" target="_blank">Arcturus Networks</a>.
+    I'm currently a SWE Intern at <a href="https://vercel.com" target="_blank">Vercel</a>. Previously, I shipped developer tooling at <a href="https://www.helicone.ai" target="_blank">Helicone</a> (YC W23), building LLM observability features, multilingual SDKs, and an open-source <a href="https://github.com/Helicone/ai-gateway" target="_blank">AI Gateway</a> in Rust. Before that, I built embedded full-stack systems at <a href="https://www.arcturusnetworks.com" target="_blank">Arcturus Networks</a>.
     <br /><br />
-    I used to run <a href="https://youtube.com/@livecode247" target="_blank">LiveCode247</a> (202K+ views, 8K watch hours), and served as President of <a href="https://exunclan.com" target="_blank">Exun Clan</a> ('22-23).
+    I ran <a href="https://youtube.com/@livecode247" target="_blank">LiveCode247</a> (202K+ views, 8K watch hours), and served as President of <a href="https://exunclan.com" target="_blank">Exun Clan</a> ('22-23).
     <br />
-    I am also the Chapter Officer at the <a href="https://new-delhi-space-society.github.io" target="_blank">New Delhi Space Society</a>, a chapter of the <a href="https://space.nss.org" target="_blank">National Space Society</a>. I am a core maintainer of <a href="https://typewind.vercel.app" target="_new">Typewind</a>
+    I am also the Chapter Officer at the <a href="https://new-delhi-space-society.github.io" target="_blank">New Delhi Space Society</a>, a chapter of the <a href="https://space.nss.org" target="_blank">National Space Society</a>. I am a core maintainer of <a href="https://typewind.vercel.app" target="_new">Typewind</a> (2.2K+ stars).
+  `,
+  work: () => `<h3>Work Experience</h3>
+    <div class="command">
+      <b class="command"><a href="https://vercel.com" target="_blank">Vercel</a></b> - SWE Intern (2025 - Present)
+      <p class="meaning">Building developer tools and infrastructure at Vercel.</p>
+    </div>
+    <div class="command">
+      <b class="command"><a href="https://www.helicone.ai" target="_blank">Helicone</a></b> - Software Engineer (YC W23) (2024)
+      <p class="meaning">Shipped LLM observability features, multilingual SDKs, production Next.js features, and built an open-source AI Gateway in Rust.</p>
+    </div>
+    <div class="command">
+      <b class="command"><a href="https://www.arcturusnetworks.com" target="_blank">Arcturus Networks</a></b> - Software Engineer (2024)
+      <p class="meaning">Built embedded full-stack systems.</p>
+    </div>
   `,
   education:
-    () => `I am a high school graduate from <a href="https://dpsrkp.net" target="_blank">Delhi Public School, R.K. Puram</a> and a freshman at <a href="https://uwaterloo.ca/content/home" target="_blank">University of Waterloo</a>.`,
+    () => `I am a high school graduate from <a href="https://dpsrkp.net" target="_blank">Delhi Public School, R.K. Puram</a> and a Computer Engineering student at the <a href="https://uwaterloo.ca/content/home" target="_blank">University of Waterloo</a> (Class of 2028).`,
   skills: () => `
-  I am experienced with Javascript, Typescript and Python and the web technologies dominating at the time:<br />
-  <div class="skill"><b>core</b>: HTML, CSS, Node.js and PHP<br /></div>
-  <div class="skill"><b>frameworks</b>: React, NextJS, Django, Express and Laravel<br /></div>
-  <div class="skill"><b>database</b>: MongoDB, PostgreSQL, MySQL, and SQLite<br /></div>
-  I also have knowledge of basic shell scripting and my dotfiles can be found <a href="https://github.com/kavinvalli/.dotfiles" target="_blank">here</a>.
+  I am experienced with Typescript, Javascript, Python and Rust and the web technologies dominating at the time:<br />
+  <div class="skill"><b>languages</b>: TypeScript, JavaScript, Python, Rust, PHP<br /></div>
+  <div class="skill"><b>frameworks</b>: React, Next.js, Django, Express, Laravel, AdonisJS<br /></div>
+  <div class="skill"><b>database</b>: PostgreSQL, MongoDB, MySQL, SQLite, ClickHouse<br /></div>
+  <div class="skill"><b>infra & tools</b>: Vercel, AWS, Docker, GitHub Actions, Neovim<br /></div>
+  I also have knowledge of shell scripting and my dotfiles can be found <a href="https://github.com/kavinvalli/dotfiles" target="_blank">here</a>.
 <br /><br />
-  I also have experience with Mobile Development with Flutter.
+  I also have experience with Mobile Development with Flutter and building developer tools & SDKs.
   `,
   projects: getProjects,
   contact: getContacts,


### PR DESCRIPTION
The terminal portfolio and its APIs were outdated - still referencing Helicone as the current position, missing Vercel entirely, listing old projects, and using stale skills.

### What changed
- **About**: Added Vercel as current SWE Intern, moved Helicone to previous experience, added AI Gateway mention and Typewind star count
- **New `work` command**: Dedicated work experience section listing Vercel, Helicone (YC W23), and Arcturus Networks with descriptions
- **Projects API**: Replaced outdated project list with current high-impact work - Helicone (5.4K stars), AI Gateway (550+ stars), Typewind (2.2K+ stars), gh-repo-fzf (45+ stars), RITA (38 stars), plus retained key older projects
- **Skills**: Added Rust, ClickHouse, AdonisJS, Vercel, AWS, Docker, GitHub Actions, Neovim; updated to TypeScript-first naming; added developer tools & SDKs experience
- **Education**: Updated from "freshman" to "Class of 2028"
- **Contacts**: Replaced Facebook with Twitter
- **README**: Rewrote with proper description and link to normal-website

A matching PR was also created for the normal-website at https://github.com/kavinvalli/normal-website/pull/3 (which fetches projects from this site's API).

<a href="https://v0-preview.slack.com/archives/C0AGMLN99R9/p1775119085969569?thread_ts=1775119085.969569&cid=C0AGMLN99R9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0chat-git-gaspar09-slack-v0-agent-routing.vercel.sh/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0chat-git-gaspar09-slack-v0-agent-routing.vercel.sh/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0chat-git-gaspar09-slack-v0-agent-routing.vercel.sh/chat-static/slack-light.svg" width="108" height="30"></picture></a>