### PR TITLE
Update site content with current experience, projects, and skills

### DIFF
--- a/app/api/contacts/route.js
+++ b/app/api/contacts/route.js
@@ -11,14 +11,14 @@ export async function GET(request) {
       link: "mailto:mail@kavin.me",
     },
     {
-      medium: "facebook",
-      username: "kavin.valli.25",
-      link: "https://www.facebook.com/kavin.valli.25/",
-    },
-    {
       medium: "linkedin",
       username: "kavinvalli",
       link: "https://www.linkedin.com/in/kavinvalli/",
+    },
+    {
+      medium: "twitter/x",
+      username: "@kavinvalli",
+      link: "https://x.com/kavinvalli",
     },
   ];
 

--- a/app/api/projects/route.js
+++ b/app/api/projects/route.js
@@ -1,70 +1,69 @@
 export async function GET(request) {
   const projects = [
     {
-      name: "Liberty: Experience the ISS like never before.",
+      name: "Helicone (YC W23)",
       description:
-        "A browser based 3D visualisation of the International Space Station in Realtime which won us second place in the NASA Space Apps Regional Round among 90+ teams.",
-      stack: ["Typescript", "NextJS", "Rust", "WASM"],
+        "Shipped 250+ merged PRs as a Software Engineer. Built the AI gateway (multi-provider proxy), LLM observability dashboard, multilingual SDKs, and production Next.js features for the open-source LLM observability platform.",
+      stack: ["TypeScript", "Next.js", "Cloudflare Workers", "PostgreSQL"],
+      link: "https://www.helicone.ai",
+      image: "exun.png",
+    },
+    {
+      name: "gh-repo-fzf",
+      description:
+        "A GitHub CLI extension for fuzzy-searching your repositories and performing actions on them. 45+ stars on GitHub.",
+      stack: ["Shell", "GitHub CLI"],
+      link: "https://github.com/kavinvalli/gh-repo-fzf",
+      image: "url.png",
+    },
+    {
+      name: "RITA - React, Inertia, TypeScript, Adonis",
+      description:
+        "A batteries-included starter for AdonisJS apps with React, Inertia.js, and TypeScript. 38+ stars.",
+      stack: ["TypeScript", "AdonisJS", "React", "Inertia.js"],
+      link: "https://github.com/kavinvalli/rita",
+      image: "cbse.png",
+    },
+    {
+      name: "Liberty: Experience the ISS",
+      description:
+        "A browser-based 3D visualization of the International Space Station in real-time. Won 2nd place at the NASA Space Apps Regional Round among 90+ teams.",
+      stack: ["TypeScript", "Next.js", "Rust", "WASM"],
       link: "https://space-apps-eosin.vercel.app",
       image: "ndss.png",
       largeImage: "liberty-lg.png",
     },
     {
-      name: "New Delhi Space Society Website",
-      description:
-        "I designed and developed New Delhi Space Society’s Website - A chapter of the National Space Society",
-      stack: ["Typescript", "NextJS"],
-      link: "https://new-delhi-space-society.github.io/",
-      image: "ndss.png",
-      largeImage: "ndss-lg.png",
-    },
-    {
-      name: "Wunderkind - DPS Goethe Quiz",
-      description:
-        "Helped in creating a platform (website) for a quiz conducted by Goethe Institut in collaboration DPS Society. The platform was used by over 9000 students in 2 iterations of the quiz and boasted a 99% availability rating. The platform was orchestrated at minimal cost to the operators and used cutting-edge web technology.",
-      stack: ["PHP", "Laravel", "Typescript", "ReactJS"],
-      link: "https://dpsgoethequiz.com",
-      image: "cognizer.png",
-    },
-    {
-      name: "Cognizer",
-      description:
-        "A Chrome Extension that allows you to connect with people during and also soon after the conference or meet ends. Second Runner's up at Code Warriors soBig.s Hackathon 2021",
-      stack: ["Javascript", "NodeJS", "Adonis", "Chrome Extension API"],
-      link: "https://cognizer.kavin.me/",
-      image: "cognizer.png",
-    },
-    {
       name: "Sudocrypt v11.0",
       description:
-        "I developed the platform for Sudocrypt v11.0, a cryptic hunt organized by Exun Clan. It had over 1.5k participants and more than 50k attempts over the course of two days.",
-      stack: ["PHP", "Laravel", "Typescript", "ReactJS"],
+        "Developed the platform for Sudocrypt v11.0, a cryptic hunt organized by Exun Clan. 1.5k+ participants and 50k+ attempts over two days. 43+ stars.",
+      stack: ["PHP", "Laravel", "TypeScript", "React"],
       link: "https://github.com/kavinvalli/sudocrypt-v11",
       image: "sudocrypt.png",
     },
     {
-      name: "CBSE Rebrand",
+      name: "Wunderkind - DPS Goethe Quiz",
       description:
-        "Rebranded CBSE Platform made using AdonisJS for CORE 2021. Creative Winners",
-      stack: ["Javascript", "NodeJS", "Adonis"],
-      link: "https://github.com/kavinvalli/core-cbse-rebrand-2021",
-      image: "cbse.png",
+        "Platform for a quiz by Goethe Institut and DPS Society. Used by 9,000+ students across 2 iterations with 99% availability.",
+      stack: ["PHP", "Laravel", "TypeScript", "React"],
+      link: "https://dpsgoethequiz.com",
+      image: "quiz.png",
     },
     {
-      name: "Discord Task Manager Bot",
+      name: "shadcn-table-v2",
       description:
-        "A Task Manager Bot you can add to your discord servers (created with the help of the Discord API)",
-      stack: ["Javascript", "NodeJS"],
-      link: "https://task-manager-bot.github.io",
-      image: "task-bot.png",
+        "A shadcn/ui table component with server-side sorting, filtering, and pagination. 7+ stars.",
+      stack: ["TypeScript", "Next.js", "shadcn/ui"],
+      link: "https://github.com/kavinvalli/shadcn-table-v2",
+      image: "url.png",
     },
     {
-      name: "Cricket VSCode Extension",
+      name: "Stripe Subscriptions Demo",
       description:
-        "A VSCode Extension to show Cricket News and LiveScores from inside the editor",
-      stack: ["Javascript"],
-      link: "https://github.com/kavin25/cricket-vscode-extension",
-      image: "cricket-vscode.png",
+        "A full-stack demo showcasing Stripe subscription integration with Next.js. 17+ stars.",
+      stack: ["TypeScript", "Next.js", "Stripe"],
+      link: "https://github.com/kavinvalli/stripe-subscriptions-demo",
+      image: "url.png",
     },
   ];
 

--- a/utils/commandHelper.js
+++ b/utils/commandHelper.js
@@ -8,6 +8,10 @@ const COMMANDS = [
     description: "My Education",
   },
   {
+    command: "experience",
+    description: "Work Experience",
+  },
+  {
     command: "skills",
     description: "My Tech Skills",
   },
@@ -78,24 +82,37 @@ export const CONTENTS = {
     ).join("") +
     `<br />
       <div class="command">Type one of the above to view. For eg. <span style="color: var(--secondary)">about</span></div>`,
-  about: () => `My name is Kavin Desi Valli. I'm a Computer Engineering student at the <a href="https://uwaterloo.ca/content/home" target="_blank">University of Waterloo</a> (CE '28) and a fullstack web developer.
+  about: () => `My name is Kavin Desi Valli. I'm a Computer Engineering student at the <a href="https://uwaterloo.ca" target="_blank">University of Waterloo</a> (CE '28) and a fullstack developer.
     <br/><br/>
-    I ship developer tooling at <a href="https://www.helicone.ai" target="_blank">Helicone</a> (YC '23), covering LLM observability, multilingual SDKs, and production-grade Next.js features, after previously building embedded full stack systems at <a href="https://www.arcturusnetworks.com" target="_blank">Arcturus Networks</a>.
+    I'm currently a Software Engineer Intern at <a href="https://vercel.com" target="_blank">Vercel</a>, working on <a href="https://v0.dev" target="_blank">v0</a>. Previously, I shipped developer tooling at <a href="https://www.helicone.ai" target="_blank">Helicone</a> (YC W23) - LLM observability, an AI gateway, multilingual SDKs, and production Next.js features (250+ merged PRs). Before that, I built embedded full-stack systems at <a href="https://www.arcturusnetworks.com" target="_blank">Arcturus Networks</a>.
     <br /><br />
-    I used to run <a href="https://youtube.com/@livecode247" target="_blank">LiveCode247</a> (202K+ views, 8K watch hours), and served as President of <a href="https://exunclan.com" target="_blank">Exun Clan</a> ('22-23).
-    <br />
-    I am also the Chapter Officer at the <a href="https://new-delhi-space-society.github.io" target="_blank">New Delhi Space Society</a>, a chapter of the <a href="https://space.nss.org" target="_blank">National Space Society</a>. I am a core maintainer of <a href="https://typewind.vercel.app" target="_new">Typewind</a>
+    I used to run <a href="https://youtube.com/@livecode247" target="_blank">LiveCode247</a> (202K+ views, 8K watch hours), and served as President of <a href="https://exunclan.com" target="_blank">Exun Clan</a> ('22-23). I am also a Chapter Officer at the <a href="https://new-delhi-space-society.github.io" target="_blank">New Delhi Space Society</a> and a core maintainer of <a href="https://typewind.vercel.app" target="_blank">Typewind</a>.
+  `,
+  experience: () => `
+  <div class="command">
+    <b class="command">Software Engineer Intern</b> @ <a href="https://vercel.com" target="_blank">Vercel</a> <span style="color: var(--secondary)">(2025 - Present)</span>
+    <p class="meaning">Working on <a href="https://v0.dev" target="_blank">v0</a>, Vercel's generative UI product.</p>
+  </div>
+  <div class="command">
+    <b class="command">Software Engineer</b> @ <a href="https://www.helicone.ai" target="_blank">Helicone</a> (YC W23) <span style="color: var(--secondary)">(2024 - 2025)</span>
+    <p class="meaning">Shipped 250+ merged PRs. Built the AI gateway (multi-provider proxy), LLM observability dashboard, multilingual SDKs (Python, TypeScript, Rust), and production Next.js features.</p>
+  </div>
+  <div class="command">
+    <b class="command">Software Engineer Intern</b> @ <a href="https://www.arcturusnetworks.com" target="_blank">Arcturus Networks</a> <span style="color: var(--secondary)">(2024)</span>
+    <p class="meaning">Built embedded full-stack systems for network infrastructure.</p>
+  </div>
   `,
   education:
-    () => `I am a high school graduate from <a href="https://dpsrkp.net" target="_blank">Delhi Public School, R.K. Puram</a> and a freshman at <a href="https://uwaterloo.ca/content/home" target="_blank">University of Waterloo</a>.`,
+    () => `I graduated from <a href="https://dpsrkp.net" target="_blank">Delhi Public School, R.K. Puram</a> (New Delhi) and am currently pursuing a Bachelor's in Computer Engineering at the <a href="https://uwaterloo.ca" target="_blank">University of Waterloo</a> (Class of 2028).`,
   skills: () => `
-  I am experienced with Javascript, Typescript and Python and the web technologies dominating at the time:<br />
-  <div class="skill"><b>core</b>: HTML, CSS, Node.js and PHP<br /></div>
-  <div class="skill"><b>frameworks</b>: React, NextJS, Django, Express and Laravel<br /></div>
-  <div class="skill"><b>database</b>: MongoDB, PostgreSQL, MySQL, and SQLite<br /></div>
-  I also have knowledge of basic shell scripting and my dotfiles can be found <a href="https://github.com/kavinvalli/.dotfiles" target="_blank">here</a>.
-<br /><br />
-  I also have experience with Mobile Development with Flutter.
+  Experienced with TypeScript, JavaScript, Python, Rust, and PHP.<br /><br />
+  <div class="skill"><b>languages</b>: TypeScript, JavaScript, Python, Rust, PHP, Lua, SQL<br /></div>
+  <div class="skill"><b>frameworks</b>: Next.js, React, Node.js, Express, Django, Laravel, AdonisJS<br /></div>
+  <div class="skill"><b>infrastructure</b>: Cloudflare Workers, Vercel, AWS, Docker<br /></div>
+  <div class="skill"><b>databases</b>: PostgreSQL, MongoDB, MySQL, SQLite, ClickHouse<br /></div>
+  <div class="skill"><b>tools</b>: Git, Neovim, tmux, fish shell (<a href="https://github.com/kavinvalli/dotfiles" target="_blank">dotfiles</a>)<br /></div>
+  <br />
+  Also experienced with Flutter for mobile development.
   `,
   projects: getProjects,
   contact: getContacts,


### PR DESCRIPTION
The terminal portfolio at kavin.me was outdated — missing the Vercel internship, Helicone work, and recent projects.

### What changed
- **About**: Now highlights current SWE intern role at Vercel (v0), Helicone experience (250+ merged PRs, AI gateway, SDKs), and Arcturus Networks
- **New `experience` command**: Dedicated work history section with Vercel, Helicone (YC W23), and Arcturus Networks
- **Skills**: Added Rust, Lua, ClickHouse, Cloudflare Workers, Docker, Neovim/tmux/fish tooling; reorganized into languages/frameworks/infra/databases/tools
- **Projects**: Replaced older/less relevant projects with Helicone, gh-repo-fzf (45 stars), RITA (38 stars), shadcn-table-v2, and Stripe subscriptions demo while keeping Liberty and Sudocrypt
- **Contacts**: Replaced Facebook with Twitter/X
- **Education**: Updated from "freshman" to "Class of 2028"

Companion PR for the normal-website (n.kavin.me): https://github.com/kavinvalli/normal-website/pull/4

<a href="https://v0-preview.slack.com/archives/C0AGMLN99R9/p1775153474754839?thread_ts=1775153474.754839&cid=C0AGMLN99R9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://v0chat-git-gaspar09-slack-v0-agent-routing.vercel.sh/chat-static/slack-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://v0chat-git-gaspar09-slack-v0-agent-routing.vercel.sh/chat-static/slack-light.svg"><img alt="Slack Thread" src="https://v0chat-git-gaspar09-slack-v0-agent-routing.vercel.sh/chat-static/slack-light.svg" width="108" height="30"></picture></a>